### PR TITLE
Add navigation arrows and pagination indicators to features slider

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -257,6 +257,48 @@ main section {
   border: 1px solid rgba(82, 96, 109, 0.08);
 }
 
+.features-slider__pagination {
+  position: absolute;
+  top: clamp(1rem, 4vw, 1.75rem);
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  gap: 0.65rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 12px 28px rgba(23, 33, 51, 0.12);
+  backdrop-filter: blur(10px);
+  z-index: 2;
+}
+
+.features-slider__pagination-item {
+  width: clamp(0.5rem, 0.9vw, 0.6rem);
+  height: clamp(0.5rem, 0.9vw, 0.6rem);
+  border-radius: 999px;
+  border: none;
+  background: color-mix(in srgb, var(--pagination-accent, var(--color-accent)) 28%, transparent);
+  cursor: pointer;
+  transition: width 0.35s ease, background 0.35s ease, box-shadow 0.35s ease;
+  box-shadow: inset 0 0 0 1px rgba(82, 96, 109, 0.18);
+  padding: 0;
+}
+
+.features-slider__pagination-item.is-active {
+  width: clamp(1.75rem, 3.2vw, 2.25rem);
+  background: var(--pagination-accent, var(--color-accent));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4), 0 6px 12px rgba(92, 110, 252, 0.2);
+}
+
+.features-slider__pagination-item:focus-visible {
+  outline: 3px solid var(--pagination-accent, var(--color-accent));
+  outline-offset: 3px;
+}
+
+.features-slider__pagination-item:hover {
+  background: color-mix(in srgb, var(--pagination-accent, var(--color-accent)) 48%, transparent);
+}
+
 .features-slider::before {
   content: '';
   position: absolute;
@@ -291,6 +333,49 @@ main section {
   transform: translateY(24px);
   transition: opacity 0.6s ease, transform 0.6s ease;
   pointer-events: none;
+}
+
+.features-slider__arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: clamp(2.75rem, 5vw, 3.25rem);
+  height: clamp(2.75rem, 5vw, 3.25rem);
+  border-radius: 50%;
+  border: 1px solid rgba(82, 96, 109, 0.14);
+  background: rgba(255, 255, 255, 0.88);
+  color: var(--color-text);
+  box-shadow: 0 14px 32px rgba(31, 41, 51, 0.16);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease,
+    color 0.25s ease;
+  z-index: 2;
+}
+
+.features-slider__arrow span {
+  font-size: clamp(1.15rem, 2.5vw, 1.45rem);
+  line-height: 1;
+}
+
+.features-slider__arrow--prev {
+  left: clamp(0.75rem, 2.5vw, 1.5rem);
+}
+
+.features-slider__arrow--next {
+  right: clamp(0.75rem, 2.5vw, 1.5rem);
+}
+
+.features-slider__arrow:hover {
+  transform: translateY(-50%) scale(1.04);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 16px 36px rgba(31, 41, 51, 0.22);
+}
+
+.features-slider__arrow:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 3px;
 }
 
 .feature-slide.is-active {

--- a/index.html
+++ b/index.html
@@ -76,6 +76,36 @@
             aria-label="Funciones destacadas de Gingnor"
             data-autoplay="6500"
           >
+            <div
+              class="features-slider__pagination"
+              role="tablist"
+              aria-label="Indicador de página del slider"
+            >
+              <button
+                type="button"
+                class="features-slider__pagination-item is-active"
+                data-target="0"
+                style="--pagination-accent: #5c6efc"
+              >
+                <span class="sr-only">Ir a Notas conectadas</span>
+              </button>
+              <button
+                type="button"
+                class="features-slider__pagination-item"
+                data-target="1"
+                style="--pagination-accent: #ff7a59"
+              >
+                <span class="sr-only">Ir a Calendario</span>
+              </button>
+              <button
+                type="button"
+                class="features-slider__pagination-item"
+                data-target="2"
+                style="--pagination-accent: #11b5a4"
+              >
+                <span class="sr-only">Ir a Automatizaciones</span>
+              </button>
+            </div>
             <div class="features-slider__viewport" aria-live="polite">
               <article
                 class="feature-slide is-active"
@@ -174,6 +204,20 @@
                 </div>
               </article>
             </div>
+            <button
+              type="button"
+              class="features-slider__arrow features-slider__arrow--prev"
+              aria-label="Ver función anterior"
+            >
+              <span aria-hidden="true">&#10094;</span>
+            </button>
+            <button
+              type="button"
+              class="features-slider__arrow features-slider__arrow--next"
+              aria-label="Ver función siguiente"
+            >
+              <span aria-hidden="true">&#10095;</span>
+            </button>
             <div class="features-slider__controls" role="tablist" aria-label="Cambiar función destacada">
               <button
                 type="button"

--- a/js/main.js
+++ b/js/main.js
@@ -44,6 +44,11 @@ const slider = document.querySelector('.features-slider');
 if (slider) {
   const slides = Array.from(slider.querySelectorAll('.feature-slide'));
   const controls = Array.from(slider.querySelectorAll('.features-slider__control'));
+  const paginationItems = Array.from(
+    slider.querySelectorAll('.features-slider__pagination-item'),
+  );
+  const prevButton = slider.querySelector('.features-slider__arrow--prev');
+  const nextButton = slider.querySelector('.features-slider__arrow--next');
   const totalSlides = slides.length;
   let currentIndex = Math.max(
     0,
@@ -77,6 +82,12 @@ if (slider) {
       control.classList.toggle('is-active', isActive);
       control.setAttribute('aria-selected', String(isActive));
       control.setAttribute('tabindex', isActive ? '0' : '-1');
+    });
+
+    paginationItems.forEach((item, index) => {
+      const isActive = index === nextIndex;
+      item.classList.toggle('is-active', isActive);
+      item.setAttribute('aria-pressed', String(isActive));
     });
 
     currentIndex = nextIndex;
@@ -153,6 +164,24 @@ if (slider) {
       }
     });
   });
+
+  paginationItems.forEach((item, index) => {
+    item.addEventListener('click', () => {
+      goToSlide(index);
+    });
+  });
+
+  if (prevButton) {
+    prevButton.addEventListener('click', () => {
+      goToSlide(currentIndex - 1);
+    });
+  }
+
+  if (nextButton) {
+    nextButton.addEventListener('click', () => {
+      goToSlide(currentIndex + 1);
+    });
+  }
 
   slider.addEventListener('mouseenter', pauseAutoplay);
   slider.addEventListener('mouseleave', resumeAutoplayIfAllowed);


### PR DESCRIPTION
## Summary
- add a top pagination bar with clickable indicators that reflect the active slide
- introduce stylized previous and next arrow buttons that match the slider aesthetic
- update slider logic to wire the new controls into the existing autoplay behavior

## Testing
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68dd92fea354832db5aa6afa7e8d0483