### PR TITLE
Improve feature slider interactions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -255,6 +255,7 @@ main section {
   box-shadow: var(--shadow-soft);
   overflow: hidden;
   border: 1px solid rgba(82, 96, 109, 0.08);
+  --drag-offset: 0px;
 }
 
 .features-slider__pagination {
@@ -273,8 +274,8 @@ main section {
 }
 
 .features-slider__pagination-item {
-  width: clamp(0.5rem, 0.9vw, 0.6rem);
-  height: clamp(0.5rem, 0.9vw, 0.6rem);
+  width: clamp(0.7rem, 1.4vw, 0.95rem);
+  height: clamp(0.7rem, 1.4vw, 0.95rem);
   border-radius: 999px;
   border: none;
   background: color-mix(in srgb, var(--pagination-accent, var(--color-accent)) 28%, transparent);
@@ -285,9 +286,9 @@ main section {
 }
 
 .features-slider__pagination-item.is-active {
-  width: clamp(1.75rem, 3.2vw, 2.25rem);
+  width: clamp(2.1rem, 4vw, 2.85rem);
   background: var(--pagination-accent, var(--color-accent));
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4), 0 6px 12px rgba(92, 110, 252, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4), 0 6px 16px rgba(92, 110, 252, 0.22);
 }
 
 .features-slider__pagination-item:focus-visible {
@@ -314,6 +315,12 @@ main section {
   isolation: isolate;
   min-height: clamp(24rem, 52vw, 29rem);
   margin-inline: auto;
+  cursor: grab;
+  touch-action: pan-y;
+}
+
+.features-slider.is-grabbing .features-slider__viewport {
+  cursor: grabbing;
 }
 
 .feature-slide {
@@ -330,9 +337,10 @@ main section {
   backdrop-filter: blur(6px);
   overflow: hidden;
   opacity: 0;
-  transform: translateY(24px);
-  transition: opacity 0.6s ease, transform 0.6s ease;
+  transform: translateX(110%) scale(0.92);
+  transition: transform 0.6s ease, opacity 0.6s ease, filter 0.6s ease;
   pointer-events: none;
+  filter: blur(0);
 }
 
 .features-slider__arrow {
@@ -380,9 +388,36 @@ main section {
 
 .feature-slide.is-active {
   opacity: 1;
-  transform: translateY(0);
+  transform: translateX(calc(0% + var(--drag-offset, 0px))) scale(1);
   pointer-events: auto;
+  z-index: 2;
+  filter: blur(0);
+}
+
+.feature-slide.is-prev,
+.feature-slide.is-next {
+  opacity: 0.75;
+  pointer-events: auto;
+  filter: blur(8px);
   z-index: 1;
+}
+
+.feature-slide.is-prev {
+  transform: translateX(calc(-56% + var(--drag-offset, 0px))) scale(0.9);
+}
+
+.feature-slide.is-next {
+  transform: translateX(calc(56% + var(--drag-offset, 0px))) scale(0.9);
+}
+
+.feature-slide.is-dormant {
+  opacity: 0;
+  transform: translateX(110%) scale(0.9);
+  filter: blur(0);
+}
+
+.features-slider.is-dragging .feature-slide {
+  transition: none;
 }
 
 .feature-slide__media {
@@ -471,94 +506,6 @@ main section {
   background: var(--slide-accent, var(--color-accent));
   box-shadow: 0 0 0 4px rgba(77, 111, 255, 0.16);
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--slide-accent, var(--color-accent)) 18%, transparent);
-}
-
-.features-slider__controls {
-  margin-top: clamp(1.5rem, 4vw, 2.75rem);
-  display: flex;
-  gap: 0.9rem;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.features-slider__control {
-  position: relative;
-  border: 1px solid rgba(82, 96, 109, 0.12);
-  border-radius: 999px;
-  padding: 0.85rem 1.4rem 1.2rem;
-  background: rgba(255, 255, 255, 0.72);
-  color: var(--color-muted);
-  font-family: var(--font-family);
-  font-size: 0.9rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: transform 0.3s ease, color 0.3s ease, background 0.3s ease,
-    border-color 0.3s ease, box-shadow 0.3s ease;
-  min-width: 160px;
-  backdrop-filter: blur(8px);
-  box-shadow: 0 12px 26px rgba(23, 33, 51, 0.08);
-}
-
-.features-slider__control::before,
-.features-slider__control::after {
-  content: '';
-  position: absolute;
-  left: 1.1rem;
-  right: 1.1rem;
-  bottom: 0.7rem;
-  height: 2px;
-  border-radius: 999px;
-}
-
-.features-slider__control::before {
-  background: rgba(82, 96, 109, 0.2);
-}
-
-.features-slider__control::after {
-  background: var(--control-accent, var(--color-accent));
-  transform: scaleX(0);
-  transform-origin: left;
-}
-
-.features-slider__control.is-active {
-  color: var(--color-text);
-  background: rgba(255, 255, 255, 0.94);
-  transform: translateY(-4px);
-  border-color: color-mix(in srgb, var(--control-accent, var(--color-accent)) 35%, transparent);
-}
-
-.features-slider__control.is-active::after {
-  animation: slider-progress var(--slide-duration, 6500ms) linear forwards;
-}
-
-.features-slider.is-paused .features-slider__control.is-active::after {
-  animation-play-state: paused;
-}
-
-.features-slider__control:focus-visible {
-  outline: 3px solid var(--control-accent, var(--color-accent));
-  outline-offset: 3px;
-}
-
-.features-slider__control:hover {
-  background: rgba(255, 255, 255, 0.88);
-  color: var(--color-text);
-  border-color: color-mix(in srgb, var(--control-accent, var(--color-accent)) 24%, transparent);
-}
-
-.features-slider__control-label {
-  position: relative;
-  z-index: 1;
-}
-
-@keyframes slider-progress {
-  from {
-    transform: scaleX(0);
-  }
-
-  to {
-    transform: scaleX(1);
-  }
 }
 
 .features__grid {

--- a/index.html
+++ b/index.html
@@ -218,44 +218,6 @@
             >
               <span aria-hidden="true">&#10095;</span>
             </button>
-            <div class="features-slider__controls" role="tablist" aria-label="Cambiar función destacada">
-              <button
-                type="button"
-                class="features-slider__control is-active"
-                role="tab"
-                aria-selected="true"
-                aria-controls="feature-slide-1"
-                data-target="0"
-                id="feature-tab-1"
-                style="--control-accent: #5c6efc"
-              >
-                <span class="features-slider__control-label">Notas conectadas</span>
-              </button>
-              <button
-                type="button"
-                class="features-slider__control"
-                role="tab"
-                aria-selected="false"
-                aria-controls="feature-slide-2"
-                data-target="1"
-                id="feature-tab-2"
-                style="--control-accent: #ff7a59"
-              >
-                <span class="features-slider__control-label">Calendario</span>
-              </button>
-              <button
-                type="button"
-                class="features-slider__control"
-                role="tab"
-                aria-selected="false"
-                aria-controls="feature-slide-3"
-                data-target="2"
-                id="feature-tab-3"
-                style="--control-accent: #11b5a4"
-              >
-                <span class="features-slider__control-label">Automatizaciones</span>
-              </button>
-            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- remove the bottom slider control buttons and rely on the dot pagination for navigation
- expand the slider styling to surface blurred previews of adjacent slides and enlarge the pagination dots
- refactor the slider script to manage prev/next states, autoplay, and pointer dragging to swipe between slides

## Testing
- python3 -m http.server 8000 (manual preview)


------
https://chatgpt.com/codex/tasks/task_e_68dd95fce240832d9b671c4fb55b360c