### PR TITLE
Remove slider wrapper and disable image selection

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -432,6 +432,7 @@ main section {
   width: 100%;
   object-fit: cover;
   box-shadow: var(--shadow-soft);
+  user-select: none;
 }
 
 .feature-slide__overlay {

--- a/index.html
+++ b/index.html
@@ -69,13 +69,12 @@
             materializar tus objetivos sin distracciones innecesarias.
           </p>
         </div>
-        <div class="container container--wide">
-          <div
-            class="features-slider"
-            role="region"
-            aria-label="Funciones destacadas de Gingnor"
-            data-autoplay="6500"
-          >
+        <div
+          class="features-slider"
+          role="region"
+          aria-label="Funciones destacadas de Gingnor"
+          data-autoplay="6500"
+        >
             <div
               class="features-slider__pagination"
               role="tablist"
@@ -218,7 +217,6 @@
             >
               <span aria-hidden="true">&#10095;</span>
             </button>
-          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- remove the extra container wrapper around the features slider to avoid an extra border
- prevent the slider images from being selected during navigation by setting user-select to none

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd9d23c0e4832d808bc1469ebf996d