### PR TITLE
Prevent dragging slider images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -433,6 +433,7 @@ main section {
   object-fit: cover;
   box-shadow: var(--shadow-soft);
   user-select: none;
+  -webkit-user-drag: none;
 }
 
 .feature-slide__overlay {

--- a/index.html
+++ b/index.html
@@ -118,6 +118,7 @@
                     src="https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=800&q=80"
                     alt="Tablero con notas de proyectos"
                     loading="lazy"
+                    draggable="false"
                   />
                   <div class="feature-slide__overlay">
                     <span>Recordatorios conectados</span>
@@ -150,6 +151,7 @@
                     src="https://images.unsplash.com/photo-1659428167876-a5a52756f421?auto=format&fit=crop&w=800&q=80"
                     alt="Calendario digital"
                     loading="lazy"
+                    draggable="false"
                   />
                   <div class="feature-slide__overlay">
                     <span>Tu semana ideal</span>
@@ -182,6 +184,7 @@
                     src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=800&q=80"
                     alt="Persona trabajando en laptop minimalista"
                     loading="lazy"
+                    draggable="false"
                   />
                   <div class="feature-slide__overlay">
                     <span>Flujos sin fricción</span>


### PR DESCRIPTION
## Summary
- add `draggable="false"` to each slider image in the features carousel
- prevent browser drag gestures on those images via CSS

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dda040a630832dba1ca65fefa7fee9