### PR TITLE
Adopt pastel pink palette for the marketing site

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,11 +1,11 @@
 :root {
-  --color-background: #f8f9fb;
+  --color-background: #fef5f9;
   --color-surface: #ffffff;
-  --color-accent: #4d6fff;
-  --color-accent-soft: #eff3ff;
+  --color-accent: #f48fb1;
+  --color-accent-soft: #fde3ee;
   --color-text: #1f2933;
-  --color-muted: #52606d;
-  --color-border: #d7dce3;
+  --color-muted: #5f6775;
+  --color-border: #f8cddc;
   --font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --shadow-soft: 0 18px 42px rgba(38, 45, 58, 0.08);
   --max-width: 1100px;
@@ -22,7 +22,7 @@ html {
 body {
   margin: 0;
   font-family: var(--font-family);
-  background: linear-gradient(180deg, #f4f6ff 0%, #f9fbff 48%, #f3f6ff 100%);
+  background: linear-gradient(180deg, #fff6fa 0%, #fef9ff 48%, #fdf4f8 100%);
   color: var(--color-text);
   line-height: 1.6;
 }
@@ -83,8 +83,8 @@ ul {
   top: 0;
   z-index: 10;
   backdrop-filter: blur(12px);
-  background-color: rgba(248, 249, 251, 0.95);
-  border-bottom: 1px solid rgba(215, 220, 227, 0.8);
+  background-color: rgba(255, 246, 250, 0.95);
+  border-bottom: 1px solid rgba(248, 205, 220, 0.7);
 }
 
 .header__content {
@@ -134,9 +134,9 @@ main section {
 .hero {
   padding-top: 7rem;
   background:
-    radial-gradient(circle at 12% 18%, rgba(92, 110, 252, 0.18), transparent 58%),
-    radial-gradient(circle at 88% 8%, rgba(17, 181, 164, 0.12), transparent 55%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(255, 255, 255, 0.86));
+    radial-gradient(circle at 12% 18%, rgba(244, 143, 177, 0.25), transparent 58%),
+    radial-gradient(circle at 85% 10%, rgba(253, 227, 238, 0.8), transparent 55%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(255, 240, 246, 0.86));
 }
 
 .hero__grid {
@@ -203,13 +203,13 @@ main section {
 .button--primary {
   background-color: var(--color-accent);
   color: #fff;
-  box-shadow: 0 15px 30px rgba(77, 111, 255, 0.25);
+  box-shadow: 0 15px 30px rgba(244, 143, 177, 0.25);
   margin-bottom: 10px;
 }
 
 .button--primary:hover,
 .button--primary:focus-visible {
-  background-color: #3b59e0;
+  background-color: #f16d99;
 }
 
 .button--ghost {
@@ -244,12 +244,12 @@ main section {
 }
 
 .features {
-  background: linear-gradient(180deg, rgba(77, 111, 255, 0.08) 0%, rgba(17, 181, 164, 0.08) 100%);
+  background: linear-gradient(180deg, rgba(244, 143, 177, 0.12) 0%, rgba(186, 224, 210, 0.22) 100%);
 }
 
 .features-slider {
   position: relative;
-  background: linear-gradient(135deg, rgba(77, 111, 255, 0.06), rgba(17, 181, 164, 0.08));
+  background: linear-gradient(135deg, rgba(244, 143, 177, 0.12), rgba(186, 224, 210, 0.18));
   padding: clamp(2rem, 5vw, 3.5rem) clamp(2rem, 6vw, 3.75rem);
   /**box-shadow: var(--shadow-soft);**/
   overflow: hidden;
@@ -286,7 +286,7 @@ main section {
 .features-slider__pagination-item.is-active {
   width: clamp(2.1rem, 4vw, 2.85rem);
   background: var(--pagination-accent, var(--color-accent));
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4), 0 6px 16px rgba(92, 110, 252, 0.22);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4), 0 6px 16px rgba(244, 143, 177, 0.28);
 }
 
 .features-slider__pagination-item:focus-visible {
@@ -504,8 +504,7 @@ main section {
   height: 0.75rem;
   border-radius: 50%;
   background: var(--slide-accent, var(--color-accent));
-  box-shadow: 0 0 0 4px rgba(77, 111, 255, 0.16);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--slide-accent, var(--color-accent)) 18%, transparent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--slide-accent, var(--color-accent)) 22%, transparent);
 }
 
 .features__grid {
@@ -530,7 +529,7 @@ main section {
 .organization {
   background:
     radial-gradient(circle at 0% 80%, rgba(255, 198, 163, 0.16), transparent 55%),
-    linear-gradient(120deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 244, 236, 0.85) 55%, rgba(92, 110, 252, 0.08) 100%);
+    linear-gradient(120deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 244, 236, 0.85) 55%, rgba(244, 143, 177, 0.12) 100%);
 }
 
 .organization__grid {
@@ -564,8 +563,8 @@ main section {
 
 .community {
   background:
-    radial-gradient(circle at 88% 12%, rgba(146, 123, 255, 0.18), transparent 52%),
-    linear-gradient(135deg, rgba(255, 255, 255, 0.94) 0%, rgba(244, 246, 255, 0.9) 100%);
+    radial-gradient(circle at 88% 12%, rgba(244, 143, 177, 0.2), transparent 52%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.94) 0%, rgba(253, 236, 243, 0.9) 100%);
 }
 
 .community__grid {
@@ -604,7 +603,7 @@ main section {
 }
 
 .roadmap {
-  background: linear-gradient(135deg, rgba(77, 111, 255, 0.12), rgba(17, 181, 164, 0.12));
+  background: linear-gradient(135deg, rgba(244, 143, 177, 0.16), rgba(210, 233, 225, 0.2));
 }
 
 .roadmap__grid {
@@ -632,8 +631,8 @@ main section {
 .cta {
   padding-bottom: clamp(4rem, 8vw, 7rem);
   background:
-    radial-gradient(circle at 18% 20%, rgba(77, 111, 255, 0.12), transparent 56%),
-    linear-gradient(180deg, rgba(244, 248, 255, 0.92), rgba(255, 255, 255, 0.96));
+    radial-gradient(circle at 18% 20%, rgba(244, 143, 177, 0.18), transparent 56%),
+    linear-gradient(180deg, rgba(255, 240, 246, 0.92), rgba(255, 255, 255, 0.96));
 }
 
 .cta__content {
@@ -659,7 +658,7 @@ main section {
   border-radius: 999px;
   border: 1px solid var(--color-border);
   font-size: 1rem;
-  background: #fdfdff;
+  background: #fff7fb;
 }
 
 .cta__form input:focus-visible {
@@ -673,9 +672,9 @@ main section {
 }
 
 .site-footer {
-  border-top: 1px solid rgba(215, 220, 227, 0.6);
+  border-top: 1px solid rgba(248, 205, 220, 0.6);
   padding: 2rem 0 3rem;
-  background: #f2f4f8;
+  background: #fdeef4;
 }
 
 .footer__content {

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
                 type="button"
                 class="features-slider__pagination-item is-active"
                 data-target="0"
-                style="--pagination-accent: #5c6efc"
+                style="--pagination-accent: #f48fb1"
               >
                 <span class="sr-only">Ir a Notas conectadas</span>
               </button>
@@ -92,7 +92,7 @@
                 type="button"
                 class="features-slider__pagination-item"
                 data-target="1"
-                style="--pagination-accent: #ff7a59"
+                style="--pagination-accent: #f6c28b"
               >
                 <span class="sr-only">Ir a Calendario</span>
               </button>
@@ -100,7 +100,7 @@
                 type="button"
                 class="features-slider__pagination-item"
                 data-target="2"
-                style="--pagination-accent: #11b5a4"
+                style="--pagination-accent: #b4e2d3"
               >
                 <span class="sr-only">Ir a Automatizaciones</span>
               </button>
@@ -111,7 +111,7 @@
                 id="feature-slide-1"
                 role="tabpanel"
                 aria-labelledby="feature-tab-1"
-                style="--slide-accent: #5c6efc"
+                style="--slide-accent: #f48fb1"
               >
                 <div class="feature-slide__media" role="presentation">
                   <img
@@ -144,7 +144,7 @@
                 id="feature-slide-2"
                 role="tabpanel"
                 aria-labelledby="feature-tab-2"
-                style="--slide-accent: #ff7a59"
+                style="--slide-accent: #f6c28b"
               >
                 <div class="feature-slide__media" role="presentation">
                   <img
@@ -177,7 +177,7 @@
                 id="feature-slide-3"
                 role="tabpanel"
                 aria-labelledby="feature-tab-3"
-                style="--slide-accent: #11b5a4"
+                style="--slide-accent: #b4e2d3"
               >
                 <div class="feature-slide__media" role="presentation">
                   <img


### PR DESCRIPTION
## Summary
- refresh the global color tokens to use a pastel palette with pink as the primary brand accent
- retheme section backgrounds, buttons, and slider pagination to match the new pastel direction
- update feature slider accents to pastel variations for each slide

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dda6fe768c832d938c0cf7a8b4bc0f