### PR TITLE
Fix CORS issue on email submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # gingnor
+
+## Configuración del formulario de registro
+
+El formulario de registro utiliza una función serverless de Netlify para enviar las notificaciones por correo a través de [Resend](https://resend.com/). Para que el envío funcione correctamente debes definir las siguientes variables de entorno en tu proyecto (por ejemplo en Netlify):
+
+- `RESEND_API_KEY`
+- `RESEND_FROM_EMAIL`
+- `RESEND_TARGET_EMAIL`
+- `RESEND_SUBJECT` (opcional, cuenta con un valor por defecto)
+
+La función se encuentra en `netlify/functions/send-email.js`. Si ejecutas el proyecto de forma local con `netlify dev`, las variables de entorno pueden declararse en un archivo `.env` en la raíz del proyecto.

--- a/js/main.js
+++ b/js/main.js
@@ -1,8 +1,3 @@
-const RESEND_API_KEY = 're_ZEe3Xmxg_DLajFDgx3jGqQHSLruCAbhxk';
-const RESEND_FROM_EMAIL = 'lanzamiento@gingnor.com';
-const RESEND_TARGET_EMAIL = 'daironquebrada@gmail.com';
-const RESEND_SUBJECT = 'Nuevo registro en la lista prioritaria de Gingnor';
-
 const header = document.querySelector('.site-header');
 const toggle = document.querySelector('.navigation__toggle');
 const menu = document.getElementById('primary-menu');
@@ -44,28 +39,19 @@ const setFormMessage = (message, type = 'success') => {
 };
 
 const sendResendEmail = async (email) => {
-  const response = await fetch('https://api.resend.com/emails', {
+  const response = await fetch('/.netlify/functions/send-email', {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${RESEND_API_KEY}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      from: `Gingnor Early Access <${RESEND_FROM_EMAIL}>`,
-      to: [RESEND_TARGET_EMAIL],
-      subject: RESEND_SUBJECT,
-      reply_to: email,
-      html: `
-        <h1>Nuevo registro</h1>
-        <p>Se ha registrado un nuevo correo para la beta privada de Gingnor.</p>
-        <p><strong>Correo:</strong> ${email}</p>
-        <p>Recuerda dar seguimiento para continuar con el proceso de bienvenida.</p>
-      `,
+      email,
     }),
   });
 
   if (!response.ok) {
-    throw new Error('No fue posible enviar el correo.');
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.message || 'No fue posible enviar el correo.');
   }
 };
 

--- a/netlify/functions/send-email.js
+++ b/netlify/functions/send-email.js
@@ -1,0 +1,82 @@
+const RESEND_API_URL = 'https://api.resend.com/emails';
+
+const buildResponse = (statusCode, body) => ({
+  statusCode,
+  headers: {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  },
+  body: JSON.stringify(body),
+});
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return buildResponse(200, {});
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return buildResponse(405, { message: 'Method Not Allowed' });
+  }
+
+  const apiKey = process.env.RESEND_API_KEY;
+  const fromEmail = process.env.RESEND_FROM_EMAIL;
+  const targetEmail = process.env.RESEND_TARGET_EMAIL;
+  const subject = process.env.RESEND_SUBJECT || 'Nuevo registro en la lista prioritaria de Gingnor';
+
+  if (!apiKey || !fromEmail || !targetEmail) {
+    return buildResponse(500, {
+      message: 'La configuración del servicio de correo no está completa.',
+    });
+  }
+
+  let payload;
+
+  try {
+    payload = JSON.parse(event.body || '{}');
+  } catch (error) {
+    return buildResponse(400, { message: 'Solicitud inválida.' });
+  }
+
+  const email = String(payload.email || '').trim();
+
+  if (!email) {
+    return buildResponse(400, { message: 'El correo electrónico es obligatorio.' });
+  }
+
+  try {
+    const response = await fetch(RESEND_API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: `Gingnor Early Access <${fromEmail}>`,
+        to: [targetEmail],
+        subject,
+        reply_to: email,
+        html: `
+          <h1>Nuevo registro</h1>
+          <p>Se ha registrado un nuevo correo para la beta privada de Gingnor.</p>
+          <p><strong>Correo:</strong> ${email}</p>
+          <p>Recuerda dar seguimiento para continuar con el proceso de bienvenida.</p>
+        `,
+      }),
+    });
+
+    if (!response.ok) {
+      const details = await response.json().catch(() => ({}));
+      console.error('Error al enviar correo con Resend:', details);
+      return buildResponse(response.status, {
+        message: 'No fue posible enviar el correo.',
+      });
+    }
+
+    return buildResponse(200, { message: 'Correo enviado correctamente.' });
+  } catch (error) {
+    console.error('Error inesperado al enviar correo:', error);
+    return buildResponse(500, { message: 'Ocurrió un error al procesar tu solicitud.' });
+  }
+};


### PR DESCRIPTION
## Summary
- move the Resend email submission logic to a Netlify serverless function to avoid CORS errors
- update the frontend form handler to call the new endpoint and surface server messages
- document the environment variables required to configure the mail integration

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ddb00c4d84832d8755a4c2d002b32a