### PR TITLE
Reemplaza el envío de Resend por SMTPJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 ## Configuración del formulario de registro
 
-El formulario de registro utiliza una función serverless de Netlify para enviar las notificaciones por correo a través de [Resend](https://resend.com/). Para que el envío funcione correctamente debes definir las siguientes variables de entorno en tu proyecto (por ejemplo en Netlify):
+El formulario de registro utiliza [SMTPJS](https://smtpjs.com/) para enviar notificaciones por correo directamente desde el navegador. Debes generar un `SecureToken` en SMTPJS y reemplazar los valores de las constantes declaradas al inicio de `js/main.js`.
 
-- `RESEND_API_KEY`
-- `RESEND_FROM_EMAIL`
-- `RESEND_TARGET_EMAIL`
-- `RESEND_SUBJECT` (opcional, cuenta con un valor por defecto)
+Variables a configurar:
 
-La función se encuentra en `netlify/functions/send-email.js`. Si ejecutas el proyecto de forma local con `netlify dev`, las variables de entorno pueden declararse en un archivo `.env` en la raíz del proyecto.
+- `SMTP_SECURE_TOKEN`
+- `SMTP_FROM_EMAIL`
+- `SMTP_TARGET_EMAIL`
+- `SMTP_SUBJECT` (opcional, puedes ajustar el valor por defecto)
+
+Recuerda que los valores sensibles no deben compartirse públicamente. Si prefieres gestionar el envío desde un entorno controlado, puedes integrar los datos con tu propio backend o función serverless asegurando estas credenciales.

--- a/index.html
+++ b/index.html
@@ -365,6 +365,7 @@
       </div>
     </footer>
 
+    <script src="https://smtpjs.com/v3/smtp.js"></script>
     <script src="js/main.js"></script>
   </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,8 @@
+const SMTP_SECURE_TOKEN = 'REEMPLAZA_CON_TU_SECURE_TOKEN_SMTPJS';
+const SMTP_TARGET_EMAIL = 'daironquebrada@gmail.com';
+const SMTP_FROM_EMAIL = 'lanzamientogingnor@gingnor.com';
+const SMTP_SUBJECT = 'Hola esta persona quiere unirse al lanzamiento';
+
 const header = document.querySelector('.site-header');
 const toggle = document.querySelector('.navigation__toggle');
 const menu = document.getElementById('primary-menu');
@@ -38,24 +43,26 @@ const setFormMessage = (message, type = 'success') => {
   formMessage.dataset.variant = type;
 };
 
-const sendResendEmail = async (email) => {
-  const response = await fetch("https://api.resend.com/emails", {
-    method: "POST",
-    headers: {
-      "Authorization": "Bearer re_ZEe3Xmxg_DLajFDgx3jGqQHSLruCAbhxk",
-      "Content-Type": "application/json"
-    },
-    body: JSON.stringify({
-      from: "lanzamientogingnor@gingnor.com",
-      to: ["daironquebrada@gmail.com"],
-      subject: "Hola esta persona quiere unirse al lanzamiento",
-      html: "<p>Correo enviado sin librerías extra</p>"
-    })
+const sendEmailWithSmtpJS = async (email) => {
+  if (!window.Email || typeof window.Email.send !== 'function') {
+    throw new Error('El servicio de correo no está disponible en este momento.');
+  }
+
+  const message = await window.Email.send({
+    SecureToken: SMTP_SECURE_TOKEN,
+    To: SMTP_TARGET_EMAIL,
+    From: SMTP_FROM_EMAIL,
+    Subject: SMTP_SUBJECT,
+    Body: `
+      <h1>Nuevo registro</h1>
+      <p>Se ha registrado un nuevo correo para la beta privada de Gingnor.</p>
+      <p><strong>Correo:</strong> ${email}</p>
+      <p>Recuerda dar seguimiento para continuar con el proceso de bienvenida.</p>
+    `,
   });
 
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
-    throw new Error(error.message || 'No fue posible enviar el correo.');
+  if (String(message).toLowerCase() !== 'ok') {
+    throw new Error('No fue posible enviar el correo.');
   }
 };
 
@@ -76,7 +83,7 @@ if (form) {
     setFormMessage('Enviando tu registro...', 'info');
 
     try {
-      await sendResendEmail(email);
+      await sendEmailWithSmtpJS(email);
       form.reset();
       setFormMessage(
         '¡Listo! Revisa tu bandeja de entrada, pronto recibirás noticias y recursos exclusivos.',


### PR DESCRIPTION
## Summary
- integra SMTPJS en el formulario de registro y declara las constantes de configuración necesarias
- reemplaza la lógica de envío para usar `Email.send` y valida la respuesta del servicio
- carga el script de SMTPJS desde la plantilla principal y actualiza la documentación de configuración

## Testing
- no se realizaron pruebas (cambios en frontend estático)


------
https://chatgpt.com/codex/tasks/task_e_68de6d20a73c832db2751e7b8822be9e