### PR TITLE
Convert CTA illustration into background

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -646,6 +646,7 @@ main section {
 }
 
 .cta__content {
+  position: relative;
   background: var(--color-surface);
   border-radius: 32px;
   padding: clamp(2.5rem, 6vw, 4rem);
@@ -653,6 +654,42 @@ main section {
   box-shadow: var(--shadow-soft);
   display: grid;
   gap: 1.5rem;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.cta__content::before {
+  content: '';
+  position: absolute;
+  inset: -20% -12% -45% -12%;
+  background:
+    radial-gradient(circle at 25% 18%, rgba(244, 143, 177, 0.42), rgba(244, 143, 177, 0) 58%),
+    radial-gradient(circle at 78% 24%, rgba(179, 229, 252, 0.38), rgba(179, 229, 252, 0) 60%),
+    linear-gradient(125deg, rgba(244, 143, 177, 0.16), rgba(244, 143, 177, 0)),
+    linear-gradient(300deg, rgba(179, 229, 252, 0.18), rgba(179, 229, 252, 0));
+  filter: saturate(115%);
+  animation: ctaGlowShift 16s ease-in-out infinite;
+  z-index: 0;
+}
+
+.cta__content::after {
+  content: '';
+  position: absolute;
+  top: clamp(18%, 12vw, 28%);
+  left: 50%;
+  width: clamp(200px, 42vw, 320px);
+  height: 3px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(244, 143, 177, 0), rgba(244, 143, 177, 0.7), rgba(179, 229, 252, 0));
+  background-size: 220% 100%;
+  transform: translateX(-50%);
+  animation: ctaSparkPulse 3.2s ease-in-out infinite;
+  z-index: 0;
+}
+
+.cta__content > * {
+  position: relative;
+  z-index: 1;
 }
 
 .cta__lead {
@@ -728,70 +765,33 @@ main section {
   color: var(--color-muted);
 }
 
-.cta__illustration {
-  position: relative;
-  display: grid;
-  justify-items: center;
-  gap: 0.75rem;
-  padding: 1.5rem 0 0.5rem;
-}
-
-.cta__orb {
-  width: clamp(160px, 28vw, 220px);
-  height: clamp(160px, 28vw, 220px);
-  border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.95), rgba(244, 143, 177, 0.4));
-  box-shadow: 0 25px 60px rgba(244, 143, 177, 0.35);
-  filter: saturate(115%);
-  animation: ctaOrbFloat 11s ease-in-out infinite;
-}
-
-.cta__orb--secondary {
-  width: clamp(120px, 20vw, 160px);
-  height: clamp(120px, 20vw, 160px);
-  background: radial-gradient(circle at 70% 30%, rgba(255, 255, 255, 0.9), rgba(179, 229, 252, 0.45));
-  box-shadow: 0 20px 45px rgba(179, 229, 252, 0.3);
-  animation-delay: -4s;
-}
-
-.cta__spark {
-  width: clamp(180px, 32vw, 260px);
-  height: 3px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(244, 143, 177, 0), rgba(244, 143, 177, 0.7), rgba(179, 229, 252, 0));
-  position: relative;
-  overflow: hidden;
-}
-
-.cta__spark::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
-  animation: ctaSparkPulse 3.2s ease-in-out infinite;
-}
-
-@keyframes ctaOrbFloat {
+@keyframes ctaGlowShift {
   0%,
   100% {
-    transform: translateY(0) scale(1);
+    transform: scale(1) translateY(0);
+    opacity: 1;
   }
-  50% {
-    transform: translateY(-14px) scale(1.03);
+  45% {
+    transform: scale(1.03) translateY(-8px);
+    opacity: 0.92;
+  }
+  70% {
+    transform: scale(0.98) translateY(6px);
+    opacity: 1;
   }
 }
 
 @keyframes ctaSparkPulse {
   0%,
   100% {
-    transform: translateX(-60%);
+    background-position: 0% 50%;
     opacity: 0;
   }
-  40% {
+  45% {
     opacity: 1;
   }
   50% {
-    transform: translateX(60%);
+    background-position: 100% 50%;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -334,11 +334,6 @@
             </li>
             <li>Historias de la comunidad que te inspirarán a elevar tu organización personal.</li>
           </ul>
-          <div class="cta__illustration" aria-hidden="true">
-            <span class="cta__orb"></span>
-            <span class="cta__orb cta__orb--secondary"></span>
-            <span class="cta__spark"></span>
-          </div>
           <form class="cta__form">
             <label class="sr-only" for="email">Correo electrónico</label>
             <input


### PR DESCRIPTION
## Summary
- remove the standalone illustration markup from the CTA email section
- restyle the CTA container to render its illustration as animated background layers with pseudo-elements
- preserve CTA content styling and disclaimer formatting after the background update

## Testing
- Manual visual inspection

------
https://chatgpt.com/codex/tasks/task_e_68de7552403c832dbec77b652b8f0618