### PR TITLE
Add countdown timer for beta launch badge

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -175,16 +175,72 @@ main section {
   bottom: -1.5rem;
   right: 1.5rem;
   background: var(--color-surface);
-  padding: 1rem 1.5rem;
-  border-radius: 16px;
+  padding: 1.25rem 1.75rem;
+  border-radius: 18px;
   box-shadow: var(--shadow-soft);
-  display: grid;
-  gap: 0.25rem;
-  text-align: right;
+  text-align: center;
+  width: min(100%, 320px);
 }
 
-.hero__badge strong {
-  font-size: 1rem;
+.countdown {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.countdown__label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-accent);
+}
+
+.countdown__display {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  align-items: stretch;
+  gap: 0.45rem;
+  background: radial-gradient(circle at top, #fde3ee, rgba(253, 227, 238, 0.65));
+  padding: 0.9rem 1.1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(244, 143, 177, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+}
+
+.countdown__segment {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 0.65rem 0.5rem;
+  border-radius: 12px;
+  box-shadow: inset 0 -6px 12px rgba(244, 143, 177, 0.18);
+}
+
+.countdown__value {
+  font-size: clamp(1.5rem, 3vw, 2.35rem);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  font-family: 'Poppins', 'SFMono-Regular', 'Roboto Mono', monospace;
+  color: var(--color-text);
+}
+
+.countdown__unit {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--color-muted);
+}
+
+.countdown__separator {
+  align-self: center;
+  font-size: clamp(1.2rem, 2.5vw, 1.8rem);
+  font-weight: 600;
+  color: rgba(244, 143, 177, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .button {

--- a/index.html
+++ b/index.html
@@ -52,9 +52,33 @@
               alt="Persona organizando notas en su computador"
               loading="lazy"
             />
-            <div class="hero__badge">
-              <strong>Beta privada</strong>
-              <span>Lanzamiento Q4 · Ene - 2026</span>
+            <div
+              class="hero__badge countdown"
+              data-countdown-target="2026-01-15T00:00:00-05:00"
+              aria-live="polite"
+            >
+              <span class="countdown__label">Cuenta regresiva</span>
+              <div class="countdown__display" role="group" aria-label="Tiempo restante">
+                <div class="countdown__segment">
+                  <span class="countdown__value" data-countdown-unit="months">00</span>
+                  <span class="countdown__unit">Meses</span>
+                </div>
+                <div class="countdown__separator" aria-hidden="true">:</div>
+                <div class="countdown__segment">
+                  <span class="countdown__value" data-countdown-unit="days">00</span>
+                  <span class="countdown__unit">Días</span>
+                </div>
+                <div class="countdown__separator" aria-hidden="true">:</div>
+                <div class="countdown__segment">
+                  <span class="countdown__value" data-countdown-unit="hours">00</span>
+                  <span class="countdown__unit">Horas</span>
+                </div>
+                <div class="countdown__separator" aria-hidden="true">:</div>
+                <div class="countdown__segment">
+                  <span class="countdown__value" data-countdown-unit="seconds">00</span>
+                  <span class="countdown__unit">Segundos</span>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -32,6 +32,97 @@ if (toggle && menu) {
   });
 }
 
+const countdownElement = document.querySelector('.countdown');
+
+if (countdownElement) {
+  const targetDateValue = countdownElement.getAttribute('data-countdown-target');
+  const targetDate = targetDateValue ? new Date(targetDateValue) : null;
+  const valueElements = {
+    months: countdownElement.querySelector('[data-countdown-unit="months"]'),
+    days: countdownElement.querySelector('[data-countdown-unit="days"]'),
+    hours: countdownElement.querySelector('[data-countdown-unit="hours"]'),
+    seconds: countdownElement.querySelector('[data-countdown-unit="seconds"]'),
+  };
+  const labelElement = countdownElement.querySelector('.countdown__label');
+
+  const updateCountdown = () => {
+    if (!targetDate || Number.isNaN(targetDate.getTime())) {
+      Object.values(valueElements).forEach((element) => {
+        if (element) {
+          element.textContent = '00';
+        }
+      });
+      return;
+    }
+
+    const now = new Date();
+    if (now >= targetDate) {
+      Object.values(valueElements).forEach((element) => {
+        if (element) {
+          element.textContent = '00';
+        }
+      });
+      if (labelElement) {
+        labelElement.textContent = '¡Lanzamiento en vivo!';
+      }
+      return;
+    }
+
+    const computeMonthsDifference = (startDate, endDate) => {
+      let months =
+        (endDate.getFullYear() - startDate.getFullYear()) * 12 +
+        (endDate.getMonth() - startDate.getMonth());
+
+      const candidate = new Date(startDate);
+      candidate.setMonth(candidate.getMonth() + months);
+
+      if (candidate > endDate) {
+        months -= 1;
+      }
+
+      return Math.max(months, 0);
+    };
+
+    const months = computeMonthsDifference(now, targetDate);
+    const baseDate = new Date(now);
+    baseDate.setMonth(baseDate.getMonth() + months);
+
+    let remaining = Math.max(targetDate.getTime() - baseDate.getTime(), 0);
+
+    const dayMs = 24 * 60 * 60 * 1000;
+    const hourMs = 60 * 60 * 1000;
+    const minuteMs = 60 * 1000;
+
+    const days = Math.floor(remaining / dayMs);
+    remaining -= days * dayMs;
+
+    const hours = Math.floor(remaining / hourMs);
+    remaining -= hours * hourMs;
+
+    const minutes = Math.floor(remaining / minuteMs);
+    remaining -= minutes * minuteMs;
+
+    const seconds = Math.floor(remaining / 1000);
+
+    const formattedValues = {
+      months: String(months).padStart(2, '0'),
+      days: String(days).padStart(2, '0'),
+      hours: String(hours).padStart(2, '0'),
+      seconds: String(seconds).padStart(2, '0'),
+    };
+
+    (Object.keys(formattedValues)).forEach((unit) => {
+      const element = valueElements[unit];
+      if (element) {
+        element.textContent = formattedValues[unit];
+      }
+    });
+  };
+
+  updateCountdown();
+  window.setInterval(updateCountdown, 1000);
+}
+
 const form = document.querySelector('.cta__form');
 const formMessage = document.querySelector('.cta__form-message');
 


### PR DESCRIPTION
## Summary
- replace the beta privada badge with a live countdown display styled as a digital timer
- add countdown-specific styles for the hero badge to highlight remaining months, days, hours and seconds
- implement JavaScript logic to calculate the countdown toward the January 15, 2026 launch date and update the UI every second

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ded99937b8832d84abe9482ce5a2fb