### PR TITLE
Improve countdown styling for hero badge

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -172,75 +172,122 @@ main section {
 
 .hero__badge {
   position: absolute;
-  bottom: -1.5rem;
-  right: 1.5rem;
-  background: var(--color-surface);
-  padding: 1.25rem 1.75rem;
-  border-radius: 18px;
-  box-shadow: var(--shadow-soft);
-  text-align: center;
-  width: min(100%, 320px);
+  bottom: -2rem;
+  right: 2rem;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(255, 245, 249, 0.85));
+  padding: 1.5rem 1.75rem;
+  border-radius: 22px;
+  box-shadow: 0 24px 45px rgba(244, 143, 177, 0.18);
+  text-align: left;
+  width: min(100%, 360px);
+  border: 1px solid rgba(244, 143, 177, 0.25);
+  backdrop-filter: blur(4px);
 }
 
 .countdown {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .countdown__label {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.28em;
   color: var(--color-accent);
 }
 
 .countdown__display {
-  display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
+  display: flex;
   align-items: stretch;
-  gap: 0.45rem;
-  background: radial-gradient(circle at top, #fde3ee, rgba(253, 227, 238, 0.65));
-  padding: 0.9rem 1.1rem;
-  border-radius: 14px;
-  border: 1px solid rgba(244, 143, 177, 0.25);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+  justify-content: space-between;
+  gap: 1rem;
+  background: radial-gradient(circle at top left, rgba(244, 143, 177, 0.18), transparent 65%),
+    radial-gradient(circle at bottom right, rgba(243, 209, 220, 0.25), transparent 60%),
+    rgba(255, 255, 255, 0.9);
+  padding: 1.1rem 1.4rem;
+  border-radius: 18px;
+  border: 1px solid rgba(244, 143, 177, 0.28);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 14px 35px rgba(209, 137, 165, 0.2);
 }
 
 .countdown__segment {
+  flex: 1;
+  min-width: 70px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.35rem;
-  background: rgba(255, 255, 255, 0.8);
-  padding: 0.65rem 0.5rem;
-  border-radius: 12px;
-  box-shadow: inset 0 -6px 12px rgba(244, 143, 177, 0.18);
+  justify-content: center;
+  gap: 0.4rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0.75));
+  padding: 0.85rem 0.65rem;
+  border-radius: 16px;
+  border: 1px solid rgba(244, 143, 177, 0.35);
+  box-shadow: 0 16px 28px rgba(244, 143, 177, 0.18);
+  position: relative;
+}
+
+.countdown__segment::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: inset 0 -12px 16px rgba(244, 143, 177, 0.18);
+  opacity: 0.85;
 }
 
 .countdown__value {
-  font-size: clamp(1.5rem, 3vw, 2.35rem);
+  font-size: clamp(1.8rem, 4vw, 2.75rem);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   font-family: 'Poppins', 'SFMono-Regular', 'Roboto Mono', monospace;
   color: var(--color-text);
+  letter-spacing: 0.04em;
+  position: relative;
+  z-index: 1;
 }
 
 .countdown__unit {
   font-size: 0.7rem;
   text-transform: uppercase;
-  letter-spacing: 0.15em;
+  letter-spacing: 0.24em;
   color: var(--color-muted);
+  position: relative;
+  z-index: 1;
 }
 
 .countdown__separator {
   align-self: center;
-  font-size: clamp(1.2rem, 2.5vw, 1.8rem);
+  font-size: clamp(1.4rem, 3vw, 2rem);
   font-weight: 600;
-  color: rgba(244, 143, 177, 0.65);
+  color: rgba(244, 143, 177, 0.75);
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-inline: 0.15rem;
+}
+
+@media (max-width: 620px) {
+  .hero__badge {
+    position: static;
+    margin-top: 1.5rem;
+    width: 100%;
+  }
+
+  .countdown__display {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.6rem 0.8rem;
+  }
+
+  .countdown__segment {
+    flex: 0 0 calc(50% - 0.8rem);
+  }
+
+  .countdown__separator {
+    display: none;
+  }
 }
 
 .button {


### PR DESCRIPTION
## Summary
- refresh the hero countdown badge with a softer gradient background, border, and blur
- redesign the countdown display to feature individual cards, enhanced typography, and separators
- add responsive tweaks so the countdown stacks cleanly on small screens

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dedd2693f0832da92e9201e5c1877b