### PR TITLE
feat: habilitar integración de Vercel Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,5 +27,6 @@
         </div>
       </section>
     </main>
+    <script src="js/main.js" defer></script>
   </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -3,6 +3,17 @@ const SMTP_TARGET_EMAIL = 'daironquebrada@gmail.com';
 const SMTP_FROM_EMAIL = 'lanzamientogingnor@gingnor.com';
 const SMTP_SUBJECT = 'Hola esta persona quiere unirse al lanzamiento';
 
+const initializeVercelAnalytics = async () => {
+  try {
+    const { inject } = await import('@vercel/analytics');
+    inject();
+  } catch (error) {
+    console.warn('No fue posible inicializar Vercel Analytics.', error);
+  }
+};
+
+initializeVercelAnalytics();
+
 const header = document.querySelector('.site-header');
 const toggle = document.querySelector('.navigation__toggle');
 const menu = document.getElementById('primary-menu');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gingnor",
+  "version": "1.0.0",
+  "private": true,
+  "description": "> Una estación minimalista para planificar tu día con intención, claridad y un toque de automatización inteligente. 🌱",
+  "scripts": {
+    "test": "echo \"No hay pruebas automatizadas configuradas\""
+  },
+  "dependencies": {
+    "@vercel/analytics": "^1.5.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
### Motivation
- Añadir soporte para métricas de Vercel Analytics y preparar el proyecto para habilitar seguimiento en producción.
- El proyecto es un sitio estático (vanilla JS), por eso la integración se hace con `@vercel/analytics` en lugar de la variante React sugerida.

### Description
- Agregué `package.json` con `@vercel/analytics` en `dependencies` y configuré el proyecto como `private` para preparar la instalación; archivo modificado: `package.json`.
- Conecté el script principal en `index.html` añadiendo `<script src="js/main.js" defer></script>` para asegurar la ejecución del JS en el cliente; archivo modificado: `index.html`.
- Inicialicé Vercel Analytics en `js/main.js` mediante un `import()` dinámico y llamando a `inject()` con manejo seguro de errores para no romper la página si el paquete no está disponible; archivo modificado: `js/main.js`.

### Testing
- Ejecuté `node --check js/main.js` para validar la sintaxis del bundle de frontend y la comprobación pasó correctamente.
- Intenté correr `npm i @vercel/analytics` en este entorno para descargar la dependencia y la instalación falló con `403 Forbidden` desde el registro npm en este entorno.
- No hay pruebas automatizadas configuradas en el proyecto además de la comprobación de sintaxis mencionada.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b75af69830832d977ad41d66c45785)